### PR TITLE
Adding preprocessor directive to not include some win32 bulk

### DIFF
--- a/Hustle-Hamster/main.cpp
+++ b/Hustle-Hamster/main.cpp
@@ -11,6 +11,7 @@
  * 
 */
 #ifdef _WINDOWS
+#define WIN32_LEAN_AND_MEAN // Necessary to remove ambiguity errors caused in windows.h library
 #include <windows.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
Necessary to avoid ambiguity errors