### PR TITLE
Changing the console character encoding

### DIFF
--- a/Hustle-Hamster/main.cpp
+++ b/Hustle-Hamster/main.cpp
@@ -21,9 +21,14 @@ using namespace std;
  * @see utils.h main()
  */
 int main(){
-
-    SetConsoleCP(CP_UTF8);
-    SetConsoleOutputCP(CP_UTF8);
+    /**
+     *  Development Process only so that developers
+     *  can use MACOS and Windows
+     */
+    #ifdef _WINDOWS
+        SetConsoleCP(CP_UTF8);
+        SetConsoleOutputCP(CP_UTF8);
+    #endif
 
     TYPE("WELCOME TO HAMSTER HANGOUT");
     delay(stdDelay);

--- a/Hustle-Hamster/main.cpp
+++ b/Hustle-Hamster/main.cpp
@@ -21,6 +21,10 @@ using namespace std;
  * @see utils.h main()
  */
 int main(){
+
+    SetConsoleCP(CP_UTF8);
+    SetConsoleOutputCP(CP_UTF8);
+
     TYPE("WELCOME TO HAMSTER HANGOUT");
     delay(stdDelay);
     printHammy();


### PR DESCRIPTION
Necessary for handling apple keyboards typing single right quote mark rather than apostrophe

Worth testing on a mac (@winka826)